### PR TITLE
Allow additional optional and rest arguments in classes that implement interfaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interfaceable (0.1.1)
+    interfaceable (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ Will fail because of method signature mismatch:
         - expected arguments: (req, req)
         - actual arguments: (req, opt=)
 
+Classes may define additional optional or rest arguments.
+
+```ruby
+module Carrier
+  def call(number); end
+
+  def text(number, text); end
+end
+
+class Giffgaff
+  def call(number, *opts); end
+
+  def text(number, text, opt1 = nil, opt2 = nil); end
+end
+```
+
+This will not generate any errors since `Giffgaff` implements the required methods with correct arguments only adding new optional ones.
+
 ### Rails
 
 Mix in `Interfaceable` before any of the application code is loaded. For example, in the initializer. For extra peace of mind, you can noop interface checking in production:

--- a/lib/interfaceable/implementation_check.rb
+++ b/lib/interfaceable/implementation_check.rb
@@ -73,6 +73,16 @@ module Interfaceable
       methods - Object.methods
     end
 
+    OPTIONAL_PARAMETERS = %w[opt rest keyrest]
+
+    def check_if_parameters_are_compatible(expected_parameters, actual_parameters)
+      return false if actual_parameters.length < expected_parameters.length
+      return false if actual_parameters.take(expected_parameters.length) != expected_parameters
+
+      additional_parameters = actual_parameters[expected_parameters.length..]
+      additional_parameters.all? { OPTIONAL_PARAMETERS.include?(_1) }
+    end
+
     # rubocop:disable Metrics/MethodLength
     def check_method_signature(expected_parameters, actual_parameters)
       expected_keyword_parameters, expected_positional_parameters = simplify_parameters(
@@ -84,6 +94,9 @@ module Interfaceable
 
       return if expected_positional_parameters == actual_positional_parameters &&
                 expected_keyword_parameters == actual_keyword_parameters
+
+      return if check_if_parameters_are_compatible(expected_positional_parameters, actual_positional_parameters) &&
+                check_if_parameters_are_compatible(expected_keyword_parameters, actual_keyword_parameters)
 
       {
         expected_positional_parameters: expected_positional_parameters,

--- a/spec/implementation_check_spec.rb
+++ b/spec/implementation_check_spec.rb
@@ -49,18 +49,9 @@ RSpec.describe Interfaceable::ImplementationCheck do
         }
       }
     )
+  end
 
-    interface = Module.new do
-      def foo(aaa, bbb); end
-    end
-    klass = Class.new do
-      def foo(aaa, baz); end
-    end
-
-    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
-
-    expect(errors).to be_empty
-
+  it 'accepts additional optional arguments' do
     interface = Module.new do
       def foo(aaa, bbb); end
     end
@@ -125,15 +116,9 @@ RSpec.describe Interfaceable::ImplementationCheck do
         }
       }
     )
+  end
 
-    klass = Class.new do
-      def self.foo(aaa, bar = 1, *args); end
-    end
-
-    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
-
-    expect(errors).to be_empty
-
+  it 'accepts additional *rest argument' do
     interface = Module.new do
       def self.foo(aaa, baz = 3); end
     end
@@ -149,24 +134,8 @@ RSpec.describe Interfaceable::ImplementationCheck do
 
   it 'checks **opts argument' do
     interface = Module.new do
-      def foo(aaa, baz = 3, *args, foo:); end
-    end
-    klass = Class.new do
-      def foo(aaa, bar = 1, *args, foo:, **opts); end
-    end
-
-    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
-
-    # allow the class to have additional rest parameters
-    expect(errors).to be_empty
-
-    interface = Module.new do
       def foo(aaa, baz = 3, *args, foo:, **options); end
     end
-
-    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
-    expect(errors).to be_empty
-
     klass = Class.new do
       def foo(aaa, bar = 1, *args, foo:); end
     end
@@ -180,6 +149,20 @@ RSpec.describe Interfaceable::ImplementationCheck do
         }
       }
     )
+  end
+
+  it 'accepts additional **opts argument' do
+    interface = Module.new do
+      def foo(aaa, baz = 3, *args, foo:); end
+    end
+    klass = Class.new do
+      def foo(aaa, bar = 1, *args, foo:, **opts); end
+    end
+
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    # allow the class to have additional rest parameters
+    expect(errors).to be_empty
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/implementation_check_spec.rb
+++ b/spec/implementation_check_spec.rb
@@ -49,6 +49,29 @@ RSpec.describe Interfaceable::ImplementationCheck do
         }
       }
     )
+
+    interface = Module.new do
+      def foo(aaa, bbb); end
+    end
+    klass = Class.new do
+      def foo(aaa, baz); end
+    end
+
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    expect(errors).to be_empty
+
+    interface = Module.new do
+      def foo(aaa, bbb); end
+    end
+    klass = Class.new do
+      def foo(aaa, baz, bar = 5, err = nil); end
+    end
+
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    # allow the class to define additional optional arguments
+    expect(errors).to be_empty
   end
 
   it 'checks class method signature' do
@@ -102,6 +125,26 @@ RSpec.describe Interfaceable::ImplementationCheck do
         }
       }
     )
+
+    klass = Class.new do
+      def self.foo(aaa, bar = 1, *args); end
+    end
+
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    expect(errors).to be_empty
+
+    interface = Module.new do
+      def self.foo(aaa, baz = 3); end
+    end
+    klass = Class.new do
+      def self.foo(aaa, bar = 1, *args); end
+    end
+
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    # allow class to define an additional rest argument
+    expect(errors).to be_empty
   end
 
   it 'checks **opts argument' do
@@ -114,14 +157,8 @@ RSpec.describe Interfaceable::ImplementationCheck do
 
     errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
 
-    expect(errors[interface][:instance_method_signature_errors]).to eq(
-      {
-        foo: {
-          expected: ['req', 'opt', 'rest', :foo],
-          actual: ['req', 'opt', 'rest', :foo, 'keyrest']
-        }
-      }
-    )
+    # allow the class to have additional rest parameters
+    expect(errors).to be_empty
 
     interface = Module.new do
       def foo(aaa, baz = 3, *args, foo:, **options); end
@@ -129,6 +166,20 @@ RSpec.describe Interfaceable::ImplementationCheck do
 
     errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
     expect(errors).to be_empty
+
+    klass = Class.new do
+      def foo(aaa, bar = 1, *args, foo:); end
+    end
+    errors = Interfaceable::ImplementationCheck.new(klass).perform([interface])
+
+    expect(errors[interface][:instance_method_signature_errors]).to eq(
+      {
+        foo: {
+          expected: ['req', 'opt', 'rest', :foo, 'keyrest'],
+          actual: ['req', 'opt', 'rest', :foo]
+        }
+      }
+    )
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Hi, I noticed that method signature need to match exactly when using interfaces.
I found it quite annoying since some libraries define getter methods with additional unused rest arguments eg. `ActiveRecord::Attributes`. This means that I would have to define the interface with additional rest arguments and also add those rest arguments to regular manual getters in other classes.

This PR allows classes that implements interfaces to define additional optional or rest arguments.

```rb
module InterfaceOne
  def foo(a, b); end
  def bar(a); end
end

class KlassOne
  extend Interfaceable
  implements InterfaceOne

  # this will be accepted
  def foo(a, b, c = 4); end

  # this will be accepted as well
  def bar(a, *args, **kwargs); end
end

module InterfaceTwo
  def foo(a, b, c = 5); end
  def bar(a, *args); end
end

class KlassTwo
  extend Interfaceable
  implements InterfaceTwo

  # this will not be accepted
  def foo(a, b); end

  # this is invalid
  def bar(a); end
end
```